### PR TITLE
Remove nixspam blacklist

### DIFF
--- a/install/assets/functions/10-postfix
+++ b/install/assets/functions/10-postfix
@@ -610,7 +610,6 @@ postscreen_dnsbl_sites =
   list.dnswl.org=127.0.[0..255].1*-4
   list.dnswl.org=127.0.[0..255].2*-6
   list.dnswl.org=127.0.[0..255].3*-8
-  ix.dnsbl.manitu.net*2
   bl.spamcop.net*2
   bl.suomispam.net*2
   hostkarma.junkemailfilter.com=127.0.0.2*3


### PR DESCRIPTION
The maintainers of the "NixSPAM" blocklist (with a DNSBL zone of ix.dnsbl.manitu.net) have decided to shut down on January 16, 2025.